### PR TITLE
Fix scripts/download_video.py to handle errors when failed to downloa…

### DIFF
--- a/scripts/download_video.py
+++ b/scripts/download_video.py
@@ -39,7 +39,11 @@ def download_video(lang, fn_sub, outdir="video", wait_sec=10, keep_org=False):
       if cp.returncode != 0:
         print(f"Failed to download the video: url = {url}")
         continue
-      shutil.move(f"{base}.{lang}.vtt", fn["vtt"])
+      try:
+        shutil.move(f"{base}.{lang}.vtt", fn["vtt"])
+      except Exception as e:
+        print(f"Failed to rename subtitle file. The download may have failed: url = {url}, filename = {base}.{lang}.vtt, error = {e}")
+        continue
 
       # vtt -> txt (reformatting)
       txt = vtt2txt(open(fn["vtt"], "r").readlines())


### PR DESCRIPTION
…d subtitle file

Error:

```
$ python3 ./scripts/download_video.py ja ./data/ja/08M93RaBSgU.csv
  0%|                                                                                                                                                | 0/1 [00:00<?, ?it/s]08M93RaBSgU
[youtube] 08M93RaBSgU: Downloading webpage
WARNING: ja subtitles not available for 08M93RaBSgU
[download] Destination: video/ja/wav/08/08M93RaBSgU.m4a
[download] 100% of 422.73KiB in 00:00
[ffmpeg] Correcting container in "video/ja/wav/08/08M93RaBSgU.m4a"
[ffmpeg] Destination: video/ja/wav/08/08M93RaBSgU.wav
Deleting original file video/ja/wav/08/08M93RaBSgU.m4a (pass -k to keep)
  0%|                                                                                                                                                | 0/1 [00:02<?, ?it/s]
Traceback (most recent call last):
  File "/usr/lib64/python3.6/shutil.py", line 550, in move
    os.rename(src, real_dst)
FileNotFoundError: [Errno 2] No such file or directory: 'video/ja/wav/08/08M93RaBSgU.ja.vtt' -> 'video/ja/vtt/08/08M93RaBSgU.vtt'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "./scripts/download_video.py", line 67, in <module>
    dirname = download_video(args.lang, args.sublist, args.outdir)
  File "./scripts/download_video.py", line 42, in download_video
    shutil.move(f"{base}.{lang}.vtt", fn["vtt"])
  File "/usr/lib64/python3.6/shutil.py", line 564, in move
    copy_function(src, real_dst)
  File "/usr/lib64/python3.6/shutil.py", line 263, in copy2
    copyfile(src, dst, follow_symlinks=follow_symlinks)
  File "/usr/lib64/python3.6/shutil.py", line 120, in copyfile
    with open(src, 'rb') as fsrc:
FileNotFoundError: [Errno 2] No such file or directory: 'video/ja/wav/08/08M93RaBSgU.ja.vtt'
```

The content of `data/ja/08M93RaBSgU.csv` file is:

```
videoid,auto,sub,channelid
08M93RaBSgU,True,True,UCBVCi5JbYmfG3q5MEuoWdOw
```

This entry is contained in the `data/ja/202103.csv`

[This video](https://www.youtube.com/watch?v=08M93RaBSgU) contain that someone talks in English. And english subtitle is available but japanese subtitle is not available now.

An execution example after applying the patch 767169e :

```
$ python3 ./scripts/download_video.py ja ./data/ja/08M93RaBSgU.csv
  0%|                                                                                                                                                | 0/1 [00:00<?, ?it/s]08M93RaBSgU
[youtube] 08M93RaBSgU: Downloading webpage
WARNING: ja subtitles not available for 08M93RaBSgU
[download] Destination: video/ja/wav/08/08M93RaBSgU.m4a
[download] 100% of 422.73KiB in 00:00
[ffmpeg] Correcting container in "video/ja/wav/08/08M93RaBSgU.m4a"
[ffmpeg] Destination: video/ja/wav/08/08M93RaBSgU.wav
Deleting original file video/ja/wav/08/08M93RaBSgU.m4a (pass -k to keep)
Failed to rename subtitle file. The download may have failed: url = https://www.youtube.com/watch?v=08M93RaBSgU, filename = video/ja/wav/08/08M93RaBSgU.ja.vtt, error = [Errno 2] No such file or directory: 'video/ja/wav/08/08M93RaBSgU.ja.vtt'
100%|███████████████████████████████████████████████████████████████████████████████████100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:02<00:00,  2.15s/it]
save JA videos to video/ja.
```

```
$ tree video/ja
video/ja
├── txt
│   └── 08
├── vtt
│   └── 08
├── wav
│   └── 08
│       └── 08M93RaBSgU.wav
└── wav16k
    └── 08

8 directories, 1 file
```