### PR TITLE
Fix scripts/download_video.py to handle error when failed to parse su…

### DIFF
--- a/scripts/download_video.py
+++ b/scripts/download_video.py
@@ -46,9 +46,13 @@ def download_video(lang, fn_sub, outdir="video", wait_sec=10, keep_org=False):
         continue
 
       # vtt -> txt (reformatting)
-      txt = vtt2txt(open(fn["vtt"], "r").readlines())
-      with open(fn["txt"], "w") as f:
-        f.writelines([f"{t[0]:1.3f}\t{t[1]:1.3f}\t\"{t[2]}\"\n" for t in txt])
+      try:
+        txt = vtt2txt(open(fn["vtt"], "r").readlines())
+        with open(fn["txt"], "w") as f:
+          f.writelines([f"{t[0]:1.3f}\t{t[1]:1.3f}\t\"{t[2]}\"\n" for t in txt])
+      except Exception as e:
+        print(f"Falied to convert subtitle file to txt file: url = {url}, filename = {fn['vtt']}, error = {e}")
+        continue
 
       # wav -> wav16k (resampling to 16kHz, 1ch)
       wav = pydub.AudioSegment.from_file(fn["wav"], format = "wav")


### PR DESCRIPTION
…btitle file (.vtt file)

Error:

```
$ python3 ./scripts/download_video.py ja data/ja/18Zzhj6Qce0.csv
  0%|                                                                                                                                                                                      | 0/1 [00:00<?, ?it/s]18Zzhj6Qce0
[youtube] 18Zzhj6Qce0: Downloading webpage
[info] Writing video subtitles to: video/ja/wav/18/18Zzhj6Qce0.ja.vtt
[download] Destination: video/ja/wav/18/18Zzhj6Qce0.m4a
[download] 100% of 33.31MiB in 00:04
[ffmpeg] Correcting container in "video/ja/wav/18/18Zzhj6Qce0.m4a"
[ffmpeg] Destination: video/ja/wav/18/18Zzhj6Qce0.wav
Deleting original file video/ja/wav/18/18Zzhj6Qce0.m4a (pass -k to keep)
  0%|                                                                                                                                                                                      | 0/1 [00:09<?, ?it/s]
Traceback (most recent call last):
  File "./scripts/download_video.py", line 71, in <module>
    dirname = download_video(args.lang, args.sublist, args.outdir)
  File "./scripts/download_video.py", line 49, in download_video
    txt = vtt2txt(open(fn["vtt"], "r").readlines())
  File "/home/eiichiro/git/jtubespeech/scripts/util.py", line 52, in vtt2txt
    et = count_total_second(dt.strptime(m.groups()[1], "%H:%M:%S.%f"))
  File "/usr/lib64/python3.6/_strptime.py", line 565, in _strptime_datetime
    tt, fraction = _strptime(data_string, format)
  File "/usr/lib64/python3.6/_strptime.py", line 362, in _strptime
    (data_string, format))
ValueError: time data '35:37:16.000' does not match format '%H:%M:%S.%f'
```

The content of `data/ja/18Zzhj6Qce0.csv` file is:

```
videoid,auto,sub,channelid
18Zzhj6Qce0,True,True,UCWFgZcBs7cujE69QuCOZHGw
```

This entry is contained in the `data/ja/202103.csv`.

The subtitle file of [this video](https://www.youtube.com/watch?v=18Zzhj6Qce0) is semantically broken. (YouTube limits the length of videos upto 12 hours.)

```
$ tail -n 6 video/ja/vtt/18/18Zzhj6Qce0.vtt
00:35:30.367 --> 00:35:34.134
最後までご視聴いただき、ありがとうございます。

00:35:34.134 --> 35:37:16.000
。
```


An execution example after applying the patch f4a12f9 :

```
$ python3 ./scripts/download_video.py ja data/ja/18Zzhj6Qce0.csv
  0%|                                                                                                                                                                                                                                                                                                                                                              | 0/1 [00:00<?, ?it/s]18Zzhj6Qce0
[youtube] 18Zzhj6Qce0: Downloading webpage
[info] Writing video subtitles to: video/ja/wav/18/18Zzhj6Qce0.ja.vtt
[download] Destination: video/ja/wav/18/18Zzhj6Qce0.m4a
[download] 100% of 33.31MiB in 00:04
[ffmpeg] Correcting container in "video/ja/wav/18/18Zzhj6Qce0.m4a"
[ffmpeg] Destination: video/ja/wav/18/18Zzhj6Qce0.wav
Deleting original file video/ja/wav/18/18Zzhj6Qce0.m4a (pass -k to keep)
Falied to convert subtitle file to txt file: url = https://www.youtube.com/watch?v=18Zzhj6Qce0, filename = video/ja/vtt/18/18Zzhj6Qce0.vtt, error = time data '35:37:16.000' does not match format '%H:%M:%S.%f'
100%|████████████████████████████ 1/1 [00:08<00:00,  8.93s/it]
save JA videos to video/ja.
```
