### PR TITLE
Fix scripts/download_video.py to handle wav normalization errors

### DIFF
--- a/scripts/download_video.py
+++ b/scripts/download_video.py
@@ -55,9 +55,13 @@ def download_video(lang, fn_sub, outdir="video", wait_sec=10, keep_org=False):
         continue
 
       # wav -> wav16k (resampling to 16kHz, 1ch)
-      wav = pydub.AudioSegment.from_file(fn["wav"], format = "wav")
-      wav = pydub.effects.normalize(wav, 5.0).set_frame_rate(16000).set_channels(1)
-      wav.export(fn["wav16k"], format="wav", bitrate='16k') 
+      try:
+        wav = pydub.AudioSegment.from_file(fn["wav"], format = "wav")
+        wav = pydub.effects.normalize(wav, 5.0).set_frame_rate(16000).set_channels(1)
+        wav.export(fn["wav16k"], format="wav", bitrate='16k')
+      except Exception as e:
+        print(f"Failed to normalize or resample downloaded audio: url = {url}, filename = {fn['wav']}, error = {e}")
+        continue
 
       # remove original wav
       if not keep_org:


### PR DESCRIPTION
Error:

```
$ python3 ./scripts/download_video.py ja data/ja/0JSMwNgRby8.csv
  0%|                                                                                                                                                                                      | 0/1 [00:00<?, ?it/s]0JSMwNgRby8
[youtube] 0JSMwNgRby8: Downloading webpage
[info] Writing video subtitles to: video/ja/wav/0J/0JSMwNgRby8.ja.vtt
[download] Destination: video/ja/wav/0J/0JSMwNgRby8.m4a
[download] 100% of 556.09MiB in 01:26
[ffmpeg] Correcting container in "video/ja/wav/0J/0JSMwNgRby8.m4a"
[ffmpeg] Destination: video/ja/wav/0J/0JSMwNgRby8.wav
Deleting original file video/ja/wav/0J/0JSMwNgRby8.m4a (pass -k to keep)
  0%|                                                                                                                                                                                      | 0/1 [02:49<?, ?it/s]
Traceback (most recent call last):
  File "./scripts/download_video.py", line 75, in <module>
    dirname = download_video(args.lang, args.sublist, args.outdir)
  File "./scripts/download_video.py", line 59, in download_video
    wav = pydub.effects.normalize(wav, 5.0).set_frame_rate(16000).set_channels(1)
  File "/home/eiichiro/.local/lib/python3.6/site-packages/pydub/effects.py", line 40, in normalize
    peak_sample_val = seg.max
  File "/home/eiichiro/.local/lib/python3.6/site-packages/pydub/audio_segment.py", line 1097, in max
    return audioop.max(self._data, self.sample_width)
audioop.error: not a whole number of frames
```

The content of `data/ja/0JSMwNgRby8.csv` file is:

```
videoid,auto,sub,channelid
0JSMwNgRby8,False,True,UCoARdEoIIxLuoUvZngzQlTw
```

This entry is contained in the `data/ja/202103.csv` .

I'm not sure what caused the error. But I have confirmed that `pydub.effects.normalize(wav, 5.0)` throw the exception.

An execution example after applying the patch 4bda3df :

```
$ python3 ./scripts/download_video.py ja data/ja/0JSMwNgRby8.csv
[youtube] 0JSMwNgRby8: Downloading webpage
[info] Writing video subtitles to: video/ja/wav/0J/0JSMwNgRby8.ja.vtt
[download] Destination: video/ja/wav/0J/0JSMwNgRby8.m4a
[download] 100% of 556.09MiB in 01:33
[ffmpeg] Correcting container in "video/ja/wav/0J/0JSMwNgRby8.m4a"
[ffmpeg] Destination: video/ja/wav/0J/0JSMwNgRby8.wav
Deleting original file video/ja/wav/0J/0JSMwNgRby8.m4a (pass -k to keep)
Failed to normalize or resample downloaded audio: url = https://www.youtube.com/watch?v=0JSMwNgRby8, filename = video/ja/wav/0J/0JSMwNgRby8.wav, error = not a whole number of frames
save JA videos to video/ja.
```

(This is the last problem I have found.)